### PR TITLE
Fix the post type icon to handle multiple types

### DIFF
--- a/inc/admin/admin-menu-content.php
+++ b/inc/admin/admin-menu-content.php
@@ -47,7 +47,6 @@ function bapt_content_page() {
 				foreach ( $post_types as $post_type ) {
 
 					// Get this post types object.
-					// Get this post types object.
 					$post_type_obj = get_post_type_object( $post_type );
 					$post_icon     = bapt_get_content_block_dashicon( $post_type_obj );
 					?>
@@ -75,7 +74,7 @@ function bapt_content_page() {
 							<?php endif; ?>
 							<?php echo esc_html( $post_type_obj->labels->name ); ?>
 						</h2>
-						
+
 						<div class="inside">
 
 							<?php

--- a/inc/admin/admin-menu-content.php
+++ b/inc/admin/admin-menu-content.php
@@ -47,8 +47,9 @@ function bapt_content_page() {
 				foreach ( $post_types as $post_type ) {
 
 					// Get this post types object.
+					// Get this post types object.
 					$post_type_obj = get_post_type_object( $post_type );
-
+					$post_icon     = bapt_get_content_block_dashicon( $post_type_obj );
 					?>
 
 					<div class="postbox bapt-content-block bapt-content-block-<?php esc_attr_e( $post_type ); ?>">
@@ -64,8 +65,17 @@ function bapt_content_page() {
 
 						?>
 
-						<h2 class="hndle ui-sortable-handle"><span class="dashicons <?php echo esc_attr( bapt_get_content_block_dashicon( $post_type_obj ) ); ?>"></span> <?php echo esc_html( $post_type_obj->labels->name ); ?></h2>
-
+						<h2 class="hndle ui-sortable-handle">
+							<?php if ( 'url' === $post_icon ) : ?>
+								<img src="<?php echo esc_url( $post_type_obj->menu_icon ); ?>" class="dashicons">
+							<?php elseif ( 'svg' === $post_icon ) : ?>
+								<img src="<?php echo esc_attr( $post_type_obj->menu_icon ); ?>" class="dashicons svg">
+							<?php else : ?>
+								<span class="dashicons <?php echo esc_attr( $post_icon ); ?>"></span>
+							<?php endif; ?>
+							<?php echo esc_html( $post_type_obj->labels->name ); ?>
+						</h2>
+						
 						<div class="inside">
 
 							<?php

--- a/inc/bapt-functions.php
+++ b/inc/bapt-functions.php
@@ -6,8 +6,14 @@
  */
 
 /**
- * Gets the dashicon to use for a content block. If the post type was not
- * declared with a dashicon then the default post icon is returend.
+ * Gets the menu icon to use for a content block.
+ *
+ * Checks to see if the post type was registered with an inline SVG
+ * icon or a URL to an icon image first and returns a hint instead
+ * of the dashicon name. If the post type was not declared with a
+ * dashicon then the default post icon is returned.
+ *
+ * @see register_post_type() for $post_type_obj properties.
  *
  * @param  WP_Post_Type $post_type_obj the post type object to retrieve the icon from.
  * @return string             the class name of the icon to return - defaults to 'dashicons-admin-post'.

--- a/inc/bapt-functions.php
+++ b/inc/bapt-functions.php
@@ -9,14 +9,24 @@
  * Gets the dashicon to use for a content block. If the post type was not
  * declared with a dashicon then the default post icon is returend.
  *
- * @param  obj $post_type_obj the post type object to retrieve the icon from.
+ * @param  WP_Post_Type $post_type_obj the post type object to retrieve the icon from.
  * @return string             the class name of the icon to return - defaults to 'dashicons-admin-post'.
  */
 function bapt_get_content_block_dashicon( $post_type_obj ) {
 	if ( null !== $post_type_obj->menu_icon ) {
+
+		if ( strstr( $post_type_obj->menu_icon, 'data:image/svg+xml;' ) ) {
+			return 'svg';
+		}
+
+		if ( strstr( $post_type_obj->menu_icon, 'http' ) ) {
+			return 'url';
+		}
+
+		// 'none' or dashicon.
 		return $post_type_obj->menu_icon;
 	}
-	
+
 	if ( 'page' === $post_type_obj->name ) {
 		return 'dashicons-admin-page';
 	}

--- a/inc/bapt-functions.php
+++ b/inc/bapt-functions.php
@@ -15,11 +15,13 @@
 function bapt_get_content_block_dashicon( $post_type_obj ) {
 	if ( null !== $post_type_obj->menu_icon ) {
 
-		if ( strstr( $post_type_obj->menu_icon, 'data:image/svg+xml;' ) ) {
+		// Checks for an inline SVG passed as the menu icon.
+		if ( 0 === strpos( $post_type_obj->menu_icon, 'data:image/svg+xml;' ) ) {
 			return 'svg';
 		}
 
-		if ( strstr( $post_type_obj->menu_icon, 'http' ) ) {
+		// Checks for a URL to an icon file.
+		if ( 0 === strpos( $post_type_obj->menu_icon, 'http' ) ) {
 			return 'url';
 		}
 


### PR DESCRIPTION
Changes the return values of `bapt_get_content_block_dashicon()` to indicate if a menu icon is registered with a URL or an SVG string.

Extends the `h2` to handle SVG or URLs instead of just Dashicons.